### PR TITLE
グリッドレイアウトウィジェットを追加

### DIFF
--- a/lib/ui/widgets.dart
+++ b/lib/ui/widgets.dart
@@ -12,6 +12,7 @@ export "package:tellyou/ui/widgets/form/icon_button.dart";
 
 // layout
 export "package:tellyou/ui/widgets/layout/column.dart";
+export "package:tellyou/ui/widgets/layout/grid.dart";
 export "package:tellyou/ui/widgets/layout/padding.dart";
 export "package:tellyou/ui/widgets/layout/row.dart";
 export "package:tellyou/ui/widgets/layout/scaffold.dart";

--- a/lib/ui/widgets/layout/grid.dart
+++ b/lib/ui/widgets/layout/grid.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+
+class TGrid extends StatelessWidget {
+  final List<TrackSize> _rowSizes;
+  final double? _rowGap;
+  final List<TrackSize> _columnSizes;
+  final double? _columnGap;
+  final List<Widget> _children;
+
+  const TGrid({super.key, rows, rowGap, required columns, columnGap, children})
+    : _rowSizes = rows,
+      _rowGap = rowGap,
+      _columnSizes = columns,
+      _columnGap = columnGap,
+      _children = children;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutGrid(
+      rowSizes: _rowSizes,
+      rowGap: _rowGap,
+      columnSizes: _columnSizes,
+      columnGap: _columnGap,
+      children: _children,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -302,6 +302,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.21.3+1"
+  flutter_layout_grid:
+    dependency: "direct main"
+    description:
+      name: flutter_layout_grid
+      sha256: "739e568db97af031d528dfd8a80d333df0e5a310a126e087690fa42cd61dfb5f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -619,6 +627,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   recase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   path: ^1.9.1
   yaml: ^3.1.2
   intl: ^0.20.2
+  flutter_layout_grid: ^2.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# 概要

グリッドレイアウト機能を提供するTGridウィジェットを実装

## 対応Issue

- fixes: https://github.com/pkshimizu/tellyou/issues/13

## 詳細

- `TGrid`ウィジェットを新規作成
  - `flutter_layout_grid`パッケージを使用してグリッドレイアウトを実装
  - 行・列のサイズ指定機能（TrackSize）
  - 行・列のギャップ指定機能
  - 子要素の配置管理
- `flutter_layout_grid`パッケージを依存関係に追加（v2.0.8）
- ウィジェットエクスポートリストに`TGrid`を追加