### PR TITLE
SettingGitHubRepositoryTableをTGridでリファクタリング

### DIFF
--- a/lib/ui/setting/dialog.dart
+++ b/lib/ui/setting/dialog.dart
@@ -17,7 +17,7 @@ class SettingDialog extends TDialog {
           height: 300,
           children: [Expanded(child: SettingViewList())],
         ),
-        SettingViews(),
+        Expanded(child: SettingViews()),
       ],
     );
   }

--- a/lib/ui/setting/widgets/github_repository_table.dart
+++ b/lib/ui/setting/widgets/github_repository_table.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:tellyou/domain/models/github.dart';
 import 'package:tellyou/ui/widgets.dart';
 
@@ -15,34 +16,31 @@ class SettingGitHubRepositoryTable extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TColumn(
+    return TGrid(
+      rows: List.filled(_repositories.length, auto),
+      rowGap: 8.0,
+      columns: [120.px, 1.fr, 32.px],
+      columnGap: 8.0,
       children: [
-        for (GitHubRepository repository in _repositories)
+        for (GitHubRepository repository in _repositories) ...[
           TRow(
             vAlign: TRowVAlign.center,
-            gap: 2,
+            gap: 1,
             children: [
-              TRow(
-                vAlign: TRowVAlign.center,
-                width: 120,
-                gap: 1,
-                children: [
-                  TAvatar(url: _organization.avatarUrl, size: TAvatarSize.xs),
-                  TText(_organization.login),
-                ],
-              ),
-              TText("/"),
-              TRow(
-                vAlign: TRowVAlign.center,
-                gap: 1,
-                children: [
-                  TAvatar(url: repository.avatarUrl, size: TAvatarSize.xs),
-                  TText(repository.name),
-                ],
-              ),
-              TIconButton(icon: Icons.remove, onPressed: (_) {}),
+              TAvatar(url: _organization.avatarUrl, size: TAvatarSize.xs),
+              TText(_organization.login),
             ],
           ),
+          TRow(
+            vAlign: TRowVAlign.center,
+            gap: 1,
+            children: [
+              TAvatar(url: repository.avatarUrl, size: TAvatarSize.xs),
+              TText(repository.name),
+            ],
+          ),
+          TIconButton(icon: Icons.remove, onPressed: (_) {}),
+        ],
       ],
     );
   }

--- a/lib/ui/widgets/layout/grid.dart
+++ b/lib/ui/widgets/layout/grid.dart
@@ -22,7 +22,12 @@ class TGrid extends StatelessWidget {
       rowGap: _rowGap,
       columnSizes: _columnSizes,
       columnGap: _columnGap,
-      children: _children,
+      children: [
+        for (final child in _children)
+          GridPlacement(
+            child: Align(alignment: Alignment.centerLeft, child: child),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
# 概要

SettingGitHubRepositoryTableのレイアウトをTColumnからTGridに変更してテーブル構造を改善

## 対応Issue

- fixes: https://github.com/pkshimizu/tellyou/issues/14

## 詳細

- `SettingGitHubRepositoryTable`のレイアウト実装を変更
  - `TColumn`から`TGrid`を使用したグリッドレイアウトに移行
  - 3カラムのグリッド構成（組織情報: 120px固定、リポジトリ情報: 1.fr、削除ボタン: 32px固定）
  - 行・列のギャップを8pxに設定
  - ネストした`TRow`を削除してシンプルな構造に変更
- `TGrid`ウィジェットの改善
  - 子要素を`GridPlacement`でラップ
  - 各セルの内容を左揃え（`Align`）に配置
- `SettingDialog`のレイアウト修正
  - `SettingViews`を`Expanded`でラップして適切な幅制約を付与
  - グリッドレイアウトが正しく動作するように修正