### PR TITLE
import_sorterを追加してimport文を整理

### DIFF
--- a/.co.yaml
+++ b/.co.yaml
@@ -1,0 +1,19 @@
+commands:
+  lint:
+    exec:
+      - dart format lib
+      - dart fix --apply lib
+      - flutter pub run import_sorter:main
+      - flutter analyze
+    working_dir: .
+    description: lint
+  add:
+    exec:
+      - flutter pub add <args>
+    working_dir: .
+    description: add package
+  watch:
+    exec:
+      - flutter pub run build_runner watch -d
+    working_dir: .
+    description: build_runner watch

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Project
+.co.yaml

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,10 +1,7 @@
-// Dart imports:
 import "dart:io";
 
-// Package imports:
 import "package:path_provider/path_provider.dart";
 
-// Project imports:
 import "domain/values/path.dart";
 
 const env = String.fromEnvironment("env");

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -1,12 +1,12 @@
 import 'dart:developer';
 import 'dart:io';
 
+import "package:sqlite3/sqlite3.dart";
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
-import "package:sqlite3/sqlite3.dart";
-import 'package:tellyou/data/tables/github_tables.dart';
-import "package:tellyou/domain/models/github.dart";
 
+import "package:tellyou/domain/models/github.dart";
+import 'package:tellyou/data/tables/github_tables.dart';
 import '../config.dart';
 
 part "database.g.dart";

--- a/lib/domain/values/path.dart
+++ b/lib/domain/values/path.dart
@@ -1,7 +1,5 @@
-// Dart imports:
 import "dart:io";
 
-// Package imports:
 import "package:path/path.dart" as p;
 
 class Path {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:tellyou/ui/home/screen.dart';
 
 void main() {

--- a/lib/ui/colors.dart
+++ b/lib/ui/colors.dart
@@ -1,4 +1,3 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
 class TColor {

--- a/lib/ui/home/screen.dart
+++ b/lib/ui/home/screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:tellyou/ui/setting/dialog.dart';
+
 import "package:tellyou/ui/widgets.dart";
+import 'package:tellyou/ui/setting/dialog.dart';
 
 class HomeScreen extends HookConsumerWidget {
   const HomeScreen({super.key});

--- a/lib/ui/home/view_model.dart
+++ b/lib/ui/home/view_model.dart
@@ -1,4 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
 import 'package:tellyou/ui/home/state.dart';
 
 part 'view_model.g.dart';

--- a/lib/ui/setting/dialog.dart
+++ b/lib/ui/setting/dialog.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+
 import "package:tellyou/ui/setting/widgets/view_list.dart";
 import "package:tellyou/ui/setting/widgets/views.dart";
 import "package:tellyou/ui/widgets.dart";

--- a/lib/ui/setting/state.dart
+++ b/lib/ui/setting/state.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 import 'package:tellyou/domain/models/github.dart';
 
 part "state.freezed.dart";

--- a/lib/ui/setting/view_model.dart
+++ b/lib/ui/setting/view_model.dart
@@ -1,4 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
 import 'package:tellyou/domain/models/github.dart';
 import 'package:tellyou/ui/setting/state.dart';
 

--- a/lib/ui/setting/widgets/github_account_view.dart
+++ b/lib/ui/setting/widgets/github_account_view.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+
 import 'package:intl/intl.dart';
-import 'package:tellyou/domain/models/github.dart';
+
 import "package:tellyou/ui/widgets.dart";
+import 'package:tellyou/domain/models/github.dart';
 
 class SettingGitHubAccountView extends StatelessWidget {
   final GitHubAccount _account;

--- a/lib/ui/setting/widgets/github_repository_table.dart
+++ b/lib/ui/setting/widgets/github_repository_table.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+
 import 'package:tellyou/domain/models/github.dart';
 import 'package:tellyou/ui/widgets.dart';
 

--- a/lib/ui/setting/widgets/github_view.dart
+++ b/lib/ui/setting/widgets/github_view.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import "package:tellyou/ui/widgets.dart";
 import 'package:tellyou/ui/setting/view_model.dart';
 import 'package:tellyou/ui/setting/widgets/github_account_view.dart';
 import 'package:tellyou/ui/setting/widgets/github_repository_table.dart';
-import "package:tellyou/ui/widgets.dart";
 
 class SettingGitHubView extends HookConsumerWidget {
   const SettingGitHubView({super.key});

--- a/lib/ui/setting/widgets/view_list.dart
+++ b/lib/ui/setting/widgets/view_list.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:tellyou/ui/setting/state.dart';
-import 'package:tellyou/ui/setting/view_model.dart';
 
 import "package:tellyou/ui/widgets.dart";
+import 'package:tellyou/ui/setting/state.dart';
+import 'package:tellyou/ui/setting/view_model.dart';
 
 class SettingViewList extends HookConsumerWidget {
   const SettingViewList({super.key});

--- a/lib/ui/setting/widgets/views.dart
+++ b/lib/ui/setting/widgets/views.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import "package:tellyou/ui/widgets.dart";
 import 'package:tellyou/ui/setting/state.dart';
 import 'package:tellyou/ui/setting/view_model.dart';
 import 'package:tellyou/ui/setting/widgets/github_view.dart';
-import "package:tellyou/ui/widgets.dart";
 
 class SettingViews extends HookConsumerWidget {
   const SettingViews({super.key});

--- a/lib/ui/widgets/display/list.dart
+++ b/lib/ui/widgets/display/list.dart
@@ -1,5 +1,5 @@
-// Flutter imports:
 import "package:flutter/material.dart";
+
 import "package:tellyou/domain/values/path.dart" as path;
 import "package:tellyou/ui/colors.dart";
 import "package:tellyou/ui/widgets.dart";

--- a/lib/ui/widgets/display/text.dart
+++ b/lib/ui/widgets/display/text.dart
@@ -1,7 +1,5 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
-// Project imports:
 import "package:tellyou/ui/colors.dart";
 
 enum TTextStyle { headline, title, body, label }

--- a/lib/ui/widgets/feedback/dialog.dart
+++ b/lib/ui/widgets/feedback/dialog.dart
@@ -1,7 +1,5 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
-// Project imports:
 import "package:tellyou/ui/colors.dart";
 import "package:tellyou/ui/widgets.dart";
 

--- a/lib/ui/widgets/form/button.dart
+++ b/lib/ui/widgets/form/button.dart
@@ -1,10 +1,8 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
-// Project imports:
+import "package:tellyou/ui/widgets.dart";
 
 // Project imports:
-import "package:tellyou/ui/widgets.dart";
 
 enum TButtonStyle { text, outlined, elevated }
 

--- a/lib/ui/widgets/form/icon_button.dart
+++ b/lib/ui/widgets/form/icon_button.dart
@@ -1,4 +1,3 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
 class TIconButton extends StatelessWidget {

--- a/lib/ui/widgets/layout/column.dart
+++ b/lib/ui/widgets/layout/column.dart
@@ -1,4 +1,3 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
 enum TColumnVAlign {

--- a/lib/ui/widgets/layout/grid.dart
+++ b/lib/ui/widgets/layout/grid.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 
 class TGrid extends StatelessWidget {

--- a/lib/ui/widgets/layout/padding.dart
+++ b/lib/ui/widgets/layout/padding.dart
@@ -1,4 +1,3 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
 class TPadding extends StatelessWidget {

--- a/lib/ui/widgets/layout/row.dart
+++ b/lib/ui/widgets/layout/row.dart
@@ -1,4 +1,3 @@
-// Flutter imports:
 import "package:flutter/material.dart";
 
 enum TRowHAlign {

--- a/lib/ui/widgets/layout/scaffold.dart
+++ b/lib/ui/widgets/layout/scaffold.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import "package:tellyou/ui/widgets.dart";
 
 class TScaffold extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,6 +395,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  import_sorter:
+    dependency: "direct dev"
+    description:
+      name: import_sorter
+      sha256: eb15738ccead84e62c31e0208ea4e3104415efcd4972b86906ca64a1187d0836
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
   intl:
     dependency: "direct main"
     description:
@@ -864,6 +872,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  tint:
+    dependency: transitive
+    description:
+      name: tint
+      sha256: "9652d9a589f4536d5e392cf790263d120474f15da3cf1bee7f1fdb31b4de5f46"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,7 @@ dev_dependencies:
   json_serializable: ^6.10.0
   riverpod_generator: ^3.0.3
   drift_dev: ^2.29.0
+  import_sorter: ^4.6.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -112,3 +113,8 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
+
+import_sorter:
+  comments: false
+  ignored_files:
+    - \/lib\/*

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,8 +6,9 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:tellyou/main.dart';
 


### PR DESCRIPTION
# 概要

import_sorterパッケージを導入してコード品質向上のためにimport文を統一的に整理

## 対応Issue

- fixes: https://github.com/pkshimizu/tellyou/issues/8

## 詳細

- `import_sorter`パッケージを開発依存関係に追加（v4.6.0）
- プロジェクト全体のimport文を整理
  - Dart標準ライブラリ、パッケージ、プロジェクト内の順に並び替え
  - コメント形式のimport区切り（`// Flutter imports:`など）を削除
  - 空行でセクションを区切るシンプルな形式に統一
- `.co.yaml`設定ファイルを追加
  - lintコマンドにimport_sorterを統合
  - その他の開発用コマンドを定義（add, watch）
- `.gitignore`に`.co.yaml`を追加（プロジェクト固有設定のため）
- `pubspec.yaml`にimport_sorter設定を追加
  - コメント無効化
  - 自動生成ファイルを除外