### PR TITLE
データベース変数名のリファクタリング

### DIFF
--- a/lib/domain/use_cases/github/register_pat.dart
+++ b/lib/domain/use_cases/github/register_pat.dart
@@ -18,18 +18,16 @@ class GitHubRegisterPatResult {
 
 class GitHubRegisterPatUseCase
     extends UseCase<GitHubRegisterPatParams, GitHubRegisterPatResult> {
-  final Database _database;
+  final Database _db;
 
-  GitHubRegisterPatUseCase(this._database);
+  GitHubRegisterPatUseCase(this._db);
 
   @override
   Future<GitHubRegisterPatResult> execute(
     GitHubRegisterPatParams params,
   ) async {
     GitHubRestUser user = await GitHubRestClient().getUser(params.pat);
-    final account = await GitHubAccountDao(
-      _database,
-    ).createAccount(user, params.pat);
+    final account = await GitHubAccountDao(_db).createAccount(user, params.pat);
     return GitHubRegisterPatResult(account: account);
   }
 }


### PR DESCRIPTION
# 概要

データベースインスタンスの変数名を統一し、コードの可読性を向上

## 対応Issue

- fixes: https://github.com/pkshimizu/tellyou/issues/20

## 詳細

- `GitHubRegisterPatUseCase`のデータベース変数名を`_database`から`_db`に変更
- コンストラクタ呼び出しのフォーマットを改善し、より簡潔なコードに修正