### PR TITLE
Driftテーブル名の命名規則を修正

### DIFF
--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -96,7 +96,7 @@ class $GitHubAccountTableTable extends GitHubAccountTable
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
-  static const String $name = 'git_hub_account_table';
+  static const String $name = 'github_account';
   @override
   VerificationContext validateIntegrity(
     Insertable<GitHubAccount> instance, {
@@ -354,7 +354,7 @@ class $GitHubOrganizationTableTable extends GitHubOrganizationTable
     type: DriftSqlType.int,
     requiredDuringInsert: true,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES git_hub_account_table (id)',
+      'REFERENCES github_account (id)',
     ),
   );
   static const VerificationMeta _loginMeta = const VerificationMeta('login');
@@ -400,7 +400,7 @@ class $GitHubOrganizationTableTable extends GitHubOrganizationTable
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
-  static const String $name = 'git_hub_organization_table';
+  static const String $name = 'github_organization';
   @override
   VerificationContext validateIntegrity(
     Insertable<GitHubOrganization> instance, {
@@ -606,7 +606,7 @@ class $GitHubRepositoryTableTable extends GitHubRepositoryTable
     type: DriftSqlType.int,
     requiredDuringInsert: true,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'REFERENCES git_hub_organization_table (id)',
+      'REFERENCES github_organization (id)',
     ),
   );
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
@@ -652,7 +652,7 @@ class $GitHubRepositoryTableTable extends GitHubRepositoryTable
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
-  static const String $name = 'git_hub_repository_table';
+  static const String $name = 'github_repository';
   @override
   VerificationContext validateIntegrity(
     Insertable<GitHubRepository> instance, {
@@ -2079,4 +2079,4 @@ final class DatabaseProvider
   }
 }
 
-String _$databaseHash() => r'b75e890cd139885a1a0cc0aed2268e451201765d';
+String _$databaseHash() => r'7a028266ff6f736c30cbf03d3151c1d32fd383a0';

--- a/lib/data/tables/github_tables.dart
+++ b/lib/data/tables/github_tables.dart
@@ -4,6 +4,9 @@ import '../../domain/models/github.dart';
 
 @UseRowClass(GitHubAccount)
 class GitHubAccountTable extends Table {
+  @override
+  String get tableName => 'github_account';
+
   IntColumn get id => integer().autoIncrement()();
   TextColumn get login => text()();
   TextColumn get name => text()();
@@ -15,6 +18,9 @@ class GitHubAccountTable extends Table {
 
 @UseRowClass(GitHubOrganization)
 class GitHubOrganizationTable extends Table {
+  @override
+  String get tableName => 'github_organization';
+
   IntColumn get id => integer().autoIncrement()();
   IntColumn get accountId => integer().references(GitHubAccountTable, #id)();
   TextColumn get login => text()();
@@ -24,6 +30,9 @@ class GitHubOrganizationTable extends Table {
 
 @UseRowClass(GitHubRepository)
 class GitHubRepositoryTable extends Table {
+  @override
+  String get tableName => 'github_repository';
+
   IntColumn get id => integer().autoIncrement()();
   IntColumn get organizationId =>
       integer().references(GitHubOrganizationTable, #id)();

--- a/lib/ui/setting/view_model.g.dart
+++ b/lib/ui/setting/view_model.g.dart
@@ -41,7 +41,7 @@ final class SettingViewModelProvider
   }
 }
 
-String _$settingViewModelHash() => r'4ae20086720d021bb9e1ad73d856bacbe30cf71b';
+String _$settingViewModelHash() => r'2d15b5c0fd2690bb4700ed80f082d3b7aaefc099';
 
 abstract class _$SettingViewModel extends $Notifier<SettingState> {
   SettingState build();


### PR DESCRIPTION
# 概要

Driftで生成されるテーブル名から不要な接尾語を削除し、命名規則を改善

## 対応Issue

- fixes: https://github.com/pkshimizu/tellyou/issues/21

## 詳細

- 各テーブルクラスに`tableName`プロパティをオーバーライドして明示的にテーブル名を指定
- テーブル名を`git_hub_*_table`から`github_*`に変更
  - `git_hub_account_table` → `github_account`
  - `git_hub_organization_table` → `github_organization`
  - `git_hub_repository_table` → `github_repository`
- 外部キー参照も新しいテーブル名に自動更新