### PR TITLE
設定画面でGitHubアカウント情報をデータベースから表示

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(dart format:*)",
       "Bash(dart fix:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git rev-parse:*)"
     ],
     "deny": [],
     "ask": []

--- a/lib/data/daos/github/account_dao.dart
+++ b/lib/data/daos/github/account_dao.dart
@@ -32,4 +32,8 @@ class GitHubAccountDao extends DatabaseAccessor<Database>
     final query = select(gitHubAccountTable)..where((tbl) => tbl.id.equals(id));
     return await query.getSingleOrNull();
   }
+
+  Future<List<GitHubAccount>> findAll() async {
+    return await select(gitHubAccountTable).get();
+  }
 }

--- a/lib/ui/setting/view_model.dart
+++ b/lib/ui/setting/view_model.dart
@@ -1,7 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:tellyou/data/database.dart';
-import 'package:tellyou/domain/models/github.dart';
+import 'package:tellyou/data/daos/github/account_dao.dart';
 import 'package:tellyou/domain/use_cases/github/register_pat.dart';
 import 'package:tellyou/ui/setting/state.dart';
 
@@ -10,47 +10,22 @@ part "view_model.g.dart";
 @riverpod
 class SettingViewModel extends _$SettingViewModel {
   @override
-  SettingState build() {
-    return SettingState(
-      accounts: [
-        GitHubAccount(
-          id: 1,
-          login: "pkshimizu",
-          name: "Kenji Shimizu",
-          htmlUrl: "https://github.com/pkshimizu",
-          avatarUrl: "https://avatars.githubusercontent.com/u/300403?v=4",
-          pat: "",
-          patExpiredAt: DateTime(2027, 12, 31),
-          organizations: [
-            GitHubOrganization(
-              id: 1,
-              accountId: 1,
-              login: 'pkshimizu',
-              htmlUrl: "https://github.com/pkshimizu",
-              avatarUrl: "https://avatars.githubusercontent.com/u/300403?v=4",
-              repositories: [
-                GitHubRepository(
-                  id: 1,
-                  organizationId: 1,
-                  name: "tellyou",
-                  htmlUrl: "https://github.com/pkshimizu/tellyou",
-                  avatarUrl:
-                      "https://avatars.githubusercontent.com/u/300403?v=4",
-                ),
-              ],
-            ),
-          ],
-        ),
-      ],
-    );
+  Future<SettingState> build() async {
+    final db = ref.read(databaseProvider);
+    final accounts = await GitHubAccountDao(db).findAll();
+    return SettingState(accounts: accounts);
   }
 
   void changeView(SettingView view) {
-    state = state.copyWith(selectedView: view);
+    state.whenData((currentState) {
+      state = AsyncValue.data(currentState.copyWith(selectedView: view));
+    });
   }
 
-  void registerGitHubPat(String pat) {
+  Future<void> registerGitHubPat(String pat) async {
     final db = ref.read(databaseProvider);
-    GitHubRegisterPatUseCase(db)(GitHubRegisterPatParams(pat: pat));
+    await GitHubRegisterPatUseCase(db)(GitHubRegisterPatParams(pat: pat));
+    // アカウント情報を再読み込み
+    ref.invalidateSelf();
   }
 }

--- a/lib/ui/setting/view_model.g.dart
+++ b/lib/ui/setting/view_model.g.dart
@@ -13,7 +13,7 @@ part of 'view_model.dart';
 const settingViewModelProvider = SettingViewModelProvider._();
 
 final class SettingViewModelProvider
-    extends $NotifierProvider<SettingViewModel, SettingState> {
+    extends $AsyncNotifierProvider<SettingViewModel, SettingState> {
   const SettingViewModelProvider._()
     : super(
         from: null,
@@ -31,30 +31,22 @@ final class SettingViewModelProvider
   @$internal
   @override
   SettingViewModel create() => SettingViewModel();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(SettingState value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<SettingState>(value),
-    );
-  }
 }
 
-String _$settingViewModelHash() => r'2d15b5c0fd2690bb4700ed80f082d3b7aaefc099';
+String _$settingViewModelHash() => r'103f0f6b7e76ddeee20a02f93d9f90a642a87e42';
 
-abstract class _$SettingViewModel extends $Notifier<SettingState> {
-  SettingState build();
+abstract class _$SettingViewModel extends $AsyncNotifier<SettingState> {
+  FutureOr<SettingState> build();
   @$mustCallSuper
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<SettingState, SettingState>;
+    final ref = this.ref as $Ref<AsyncValue<SettingState>, SettingState>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<SettingState, SettingState>,
-              SettingState,
+              AnyNotifier<AsyncValue<SettingState>, SettingState>,
+              AsyncValue<SettingState>,
               Object?,
               Object?
             >;

--- a/lib/ui/setting/widgets/github_view.dart
+++ b/lib/ui/setting/widgets/github_view.dart
@@ -13,48 +13,53 @@ class SettingGitHubView extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(settingViewModelProvider);
+    final asyncState = ref.watch(settingViewModelProvider);
 
-    return TColumn(
-      children: [
-        TRow(
-          vAlign: TRowVAlign.center,
-          gap: 1,
-          children: [
-            TText("GitHub Accounts"),
-            TIconButton(
-              icon: Icons.add,
-              onPressed: (context) {
-                GitHubPatRegisterDialog().show(context);
-              },
-            ),
-          ],
-        ),
-        TColumn(
-          gap: 2,
-          children: [
-            for (final account in state.accounts)
-              TColumn(
+    return asyncState.when(
+      data:
+          (state) => TColumn(
+            children: [
+              TRow(
+                vAlign: TRowVAlign.center,
                 gap: 1,
                 children: [
-                  SettingGitHubAccountView(account: account),
-                  TPadding(
-                    left: 16,
-                    child: TColumn(
-                      children: [
-                        for (final organization in account.organizations)
-                          SettingGitHubRepositoryTable(
-                            organization: organization,
-                            repositories: organization.repositories,
-                          ),
-                      ],
-                    ),
+                  TText("GitHub Accounts"),
+                  TIconButton(
+                    icon: Icons.add,
+                    onPressed: (context) {
+                      GitHubPatRegisterDialog().show(context);
+                    },
                   ),
                 ],
               ),
-          ],
-        ),
-      ],
+              TColumn(
+                gap: 2,
+                children: [
+                  for (final account in state.accounts)
+                    TColumn(
+                      gap: 1,
+                      children: [
+                        SettingGitHubAccountView(account: account),
+                        TPadding(
+                          left: 16,
+                          child: TColumn(
+                            children: [
+                              for (final organization in account.organizations)
+                                SettingGitHubRepositoryTable(
+                                  organization: organization,
+                                  repositories: organization.repositories,
+                                ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ],
+          ),
+      loading: () => const TCenter(child: TProgress()),
+      error: (error, stack) => TText("Error: $error"),
     );
   }
 }

--- a/lib/ui/setting/widgets/view_list.dart
+++ b/lib/ui/setting/widgets/view_list.dart
@@ -11,29 +11,34 @@ class SettingViewList extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(settingViewModelProvider);
+    final asyncState = ref.watch(settingViewModelProvider);
 
-    return TListView(
-      items: [
-        TListItem(
-          title: "General",
-          selected: state.selectedView == SettingView.general,
-          onTap: () {
-            ref
-                .read(settingViewModelProvider.notifier)
-                .changeView(SettingView.general);
-          },
-        ),
-        TListItem(
-          title: "GitHub",
-          selected: state.selectedView == SettingView.github,
-          onTap: () {
-            ref
-                .read(settingViewModelProvider.notifier)
-                .changeView(SettingView.github);
-          },
-        ),
-      ],
+    return asyncState.when(
+      data:
+          (state) => TListView(
+            items: [
+              TListItem(
+                title: "General",
+                selected: state.selectedView == SettingView.general,
+                onTap: () {
+                  ref
+                      .read(settingViewModelProvider.notifier)
+                      .changeView(SettingView.general);
+                },
+              ),
+              TListItem(
+                title: "GitHub",
+                selected: state.selectedView == SettingView.github,
+                onTap: () {
+                  ref
+                      .read(settingViewModelProvider.notifier)
+                      .changeView(SettingView.github);
+                },
+              ),
+            ],
+          ),
+      loading: () => const TCenter(child: TProgress()),
+      error: (error, stack) => TText("Error: $error"),
     );
   }
 }

--- a/lib/ui/setting/widgets/views.dart
+++ b/lib/ui/setting/widgets/views.dart
@@ -12,16 +12,22 @@ class SettingViews extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(settingViewModelProvider);
+    final asyncState = ref.watch(settingViewModelProvider);
 
-    if (state.selectedView == SettingView.general) {
-      return TText("General");
-    }
+    return asyncState.when(
+      data: (state) {
+        if (state.selectedView == SettingView.general) {
+          return TText("General");
+        }
 
-    if (state.selectedView == SettingView.github) {
-      return SettingGitHubView();
-    }
+        if (state.selectedView == SettingView.github) {
+          return SettingGitHubView();
+        }
 
-    return TText("Unknown");
+        return TText("Unknown");
+      },
+      loading: () => const TCenter(child: TProgress()),
+      error: (error, stack) => TText("Error: $error"),
+    );
   }
 }

--- a/lib/ui/widgets.dart
+++ b/lib/ui/widgets.dart
@@ -1,6 +1,7 @@
 // display
 export "package:tellyou/ui/widgets/display/avatar.dart";
 export "package:tellyou/ui/widgets/display/list.dart";
+export "package:tellyou/ui/widgets/display/progress.dart";
 export "package:tellyou/ui/widgets/display/text.dart";
 
 // feedback
@@ -13,6 +14,7 @@ export "package:tellyou/ui/widgets/form/form_field.dart";
 export "package:tellyou/ui/widgets/form/text_field.dart";
 
 // layout
+export "package:tellyou/ui/widgets/layout/center.dart";
 export "package:tellyou/ui/widgets/layout/column.dart";
 export "package:tellyou/ui/widgets/layout/grid.dart";
 export "package:tellyou/ui/widgets/layout/padding.dart";

--- a/lib/ui/widgets/display/progress.dart
+++ b/lib/ui/widgets/display/progress.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class TProgress extends StatelessWidget {
+  const TProgress({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CircularProgressIndicator();
+  }
+}

--- a/lib/ui/widgets/layout/center.dart
+++ b/lib/ui/widgets/layout/center.dart
@@ -1,0 +1,12 @@
+import "package:flutter/material.dart";
+
+class TCenter extends StatelessWidget {
+  final Widget _child;
+
+  const TCenter({super.key, required Widget child}) : _child = child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(child: _child);
+  }
+}


### PR DESCRIPTION
# 概要

設定画面でGitHubアカウント情報をデータベースから読み込んで表示する機能を実装

## 対応Issue

- fixes: https://github.com/pkshimizu/tellyou/issues/23

## 詳細

- `GitHubAccountDao`に`findAll()`メソッドを追加してデータベースから全アカウント情報を取得
- `SettingViewModel`を`Notifier`から`AsyncNotifier`に変更
  - `build()`メソッドでデータベースからアカウント情報を非同期で読み込み
  - `registerGitHubPat()`を非同期メソッドに変更し、登録後に自動でアカウント情報を再読み込み
- UIウィジェットを`AsyncValue`に対応
  - `SettingViews`、`SettingViewList`、`SettingGitHubView`で`AsyncValue.when()`を使用
  - loading状態とerror状態を適切に処理
- 新しいUIコンポーネント追加
  - `TCenter`と`TProgress`ウィジェットを追加