### PR TITLE
GitHubアカウント追加ボタンのサイズを調整

### DIFF
--- a/lib/ui/setting/widgets/github_view.dart
+++ b/lib/ui/setting/widgets/github_view.dart
@@ -26,6 +26,7 @@ class SettingGitHubView extends HookConsumerWidget {
                   TText("GitHub Accounts"),
                   TIconButton(
                     icon: Icons.add,
+                    size: 20,
                     onPressed: (context) {
                       GitHubPatRegisterDialog().show(context);
                     },

--- a/lib/ui/widgets/form/icon_button.dart
+++ b/lib/ui/widgets/form/icon_button.dart
@@ -16,15 +16,21 @@ class TIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _sized(
-      IconButton(icon: Icon(_icon), onPressed: () => _onPressed(context)),
-    );
-  }
-
-  Widget _sized(Widget child) {
-    if (_size == null) {
-      return child;
+    if (_size != null) {
+      // サイズ指定がある場合は、アイコンサイズとパディングを調整
+      final iconSize = _size * 0.625; // アイコンサイズはボタンサイズの62.5%
+      return SizedBox(
+        width: _size,
+        height: _size,
+        child: IconButton(
+          icon: Icon(_icon, size: iconSize),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+          onPressed: () => _onPressed(context),
+        ),
+      );
     }
-    return SizedBox(width: _size, height: _size, child: child);
+
+    return IconButton(icon: Icon(_icon), onPressed: () => _onPressed(context));
   }
 }


### PR DESCRIPTION
## 概要
GitHubアカウント追加アイコンボタンのサイズを20pxに縮小し、UIをコンパクトに改善

## 対応Issue
- fixes: https://github.com/pkshimizu/tellyou/issues/26

## 詳細
- TIconButtonクラスにサイズ指定機能を実装
  - サイズ指定時にアイコンサイズを自動調整（ボタンサイズの62.5%）
  - パディングとConstraintsを最適化してコンパクトに表示
- GitHubアカウント追加ボタンに`size: 20`を指定
- デザインが崩れないようにアイコンとボタンのサイズ比率を調整