### PR TITLE
GitHubリポジトリ選択機能を追加

### DIFF
--- a/lib/data/clients/github_rest_client.dart
+++ b/lib/data/clients/github_rest_client.dart
@@ -74,8 +74,8 @@ class GitHubRestClient {
       return GitHubRestRepository(
         organization: GitHubRestOrganization(
           login: owner["login"],
-          htmlUrl: owner["htmlUrl"],
-          avatarUrl: owner["avatarUrl"],
+          htmlUrl: owner["html_url"],
+          avatarUrl: owner["avatar_url"],
         ),
         name: repoMap['name'] as String,
         htmlUrl: repoMap['html_url'] as String,

--- a/lib/data/clients/github_rest_client.dart
+++ b/lib/data/clients/github_rest_client.dart
@@ -47,9 +47,9 @@ class GitHubRestClient {
   }
 
   Future<List<GitHubRestOrganization>> getOrganizations(String pat) async {
-    // GitHub APIでリポジトリ情報を取得
-    final reposResponse = await http.get(
-      Uri.parse('$_baseUrl/users/orgs?per_page=100'),
+    // GitHub APIで組織情報を取得
+    final orgsResponse = await http.get(
+      Uri.parse('$_baseUrl/user/orgs?per_page=100'),
       headers: {
         'Authorization': 'Bearer $pat',
         'Accept': 'application/vnd.github+json',
@@ -57,16 +57,16 @@ class GitHubRestClient {
       },
     );
 
-    if (reposResponse.statusCode != 200) {
+    if (orgsResponse.statusCode != 200) {
       throw Exception(
-        'Failed to get organizations: ${reposResponse.statusCode} ${reposResponse.body}',
+        'Failed to get organizations: ${orgsResponse.statusCode} ${orgsResponse.body}',
       );
     }
 
-    final orgsData = json.decode(reposResponse.body) as List<dynamic>;
+    final orgsData = json.decode(orgsResponse.body) as List<dynamic>;
 
-    return orgsData.map((repData) {
-      final org = repData as Map<String, dynamic>;
+    return orgsData.map((orgData) {
+      final org = orgData as Map<String, dynamic>;
 
       return GitHubRestOrganization(
         login: org["login"],

--- a/lib/data/clients/github_rest_client.dart
+++ b/lib/data/clients/github_rest_client.dart
@@ -45,4 +45,42 @@ class GitHubRestClient {
       expiresAt: expiresAt,
     );
   }
+
+  Future<List<GitHubRestRepository>> getRepositories(String pat) async {
+    // GitHub APIでリポジトリ情報を取得
+    final reposResponse = await http.get(
+      Uri.parse(
+        '$_baseUrl/user/repos?per_page=100&affiliation=owner,collaborator,organization_member',
+      ),
+      headers: {
+        'Authorization': 'Bearer $pat',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    );
+
+    if (reposResponse.statusCode != 200) {
+      throw Exception(
+        'Failed to get repositories: ${reposResponse.statusCode} ${reposResponse.body}',
+      );
+    }
+
+    final reposData = json.decode(reposResponse.body) as List<dynamic>;
+
+    return reposData.map((repo) {
+      final repoMap = repo as Map<String, dynamic>;
+      final owner = repoMap['owner'] as Map<String, dynamic>;
+
+      return GitHubRestRepository(
+        organization: GitHubRestOrganization(
+          login: owner["login"],
+          htmlUrl: owner["htmlUrl"],
+          avatarUrl: owner["avatarUrl"],
+        ),
+        name: repoMap['name'] as String,
+        htmlUrl: repoMap['html_url'] as String,
+        avatarUrl: owner['avatar_url'] as String,
+      );
+    }).toList();
+  }
 }

--- a/lib/data/clients/github_rest_client.dart
+++ b/lib/data/clients/github_rest_client.dart
@@ -47,6 +47,32 @@ class GitHubRestClient {
   }
 
   Future<List<GitHubRestOrganization>> getOrganizations(String pat) async {
+    // GitHub APIでユーザー情報を取得（個人リポジトリ用）
+    final userResponse = await http.get(
+      Uri.parse('$_baseUrl/user'),
+      headers: {
+        'Authorization': 'Bearer $pat',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    );
+
+    if (userResponse.statusCode != 200) {
+      throw Exception(
+        'Failed to get user info: ${userResponse.statusCode} ${userResponse.body}',
+      );
+    }
+
+    final userData = json.decode(userResponse.body) as Map<String, dynamic>;
+
+    // 個人アカウントを組織リストの最初に追加
+    final organizations = <GitHubRestOrganization>[
+      GitHubRestOrganization(
+        login: userData["login"],
+        avatarUrl: userData["avatar_url"],
+      ),
+    ];
+
     // GitHub APIで組織情報を取得
     final orgsResponse = await http.get(
       Uri.parse('$_baseUrl/user/orgs?per_page=100'),
@@ -65,23 +91,28 @@ class GitHubRestClient {
 
     final orgsData = json.decode(orgsResponse.body) as List<dynamic>;
 
-    return orgsData.map((orgData) {
-      final org = orgData as Map<String, dynamic>;
+    // 組織リストを追加
+    organizations.addAll(
+      orgsData.map((orgData) {
+        final org = orgData as Map<String, dynamic>;
+        return GitHubRestOrganization(
+          login: org["login"],
+          avatarUrl: org["avatar_url"],
+        );
+      }),
+    );
 
-      return GitHubRestOrganization(
-        login: org["login"],
-        avatarUrl: org["avatar_url"],
-      );
-    }).toList();
+    return organizations;
   }
 
   Future<List<GitHubRestRepository>> getRepositories(
     String pat,
-    String org,
+    String owner,
   ) async {
     // GitHub APIでリポジトリ情報を取得
+    // /users/{owner}/repos は個人・組織両方に対応
     final reposResponse = await http.get(
-      Uri.parse('$_baseUrl/orgs/$org/repos?per_page=100'),
+      Uri.parse('$_baseUrl/users/$owner/repos?per_page=100'),
       headers: {
         'Authorization': 'Bearer $pat',
         'Accept': 'application/vnd.github+json',

--- a/lib/data/clients/github_rest_client.dart
+++ b/lib/data/clients/github_rest_client.dart
@@ -46,12 +46,42 @@ class GitHubRestClient {
     );
   }
 
-  Future<List<GitHubRestRepository>> getRepositories(String pat) async {
+  Future<List<GitHubRestOrganization>> getOrganizations(String pat) async {
     // GitHub APIでリポジトリ情報を取得
     final reposResponse = await http.get(
-      Uri.parse(
-        '$_baseUrl/user/repos?per_page=100&affiliation=owner,collaborator,organization_member',
-      ),
+      Uri.parse('$_baseUrl/users/orgs?per_page=100'),
+      headers: {
+        'Authorization': 'Bearer $pat',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    );
+
+    if (reposResponse.statusCode != 200) {
+      throw Exception(
+        'Failed to get organizations: ${reposResponse.statusCode} ${reposResponse.body}',
+      );
+    }
+
+    final orgsData = json.decode(reposResponse.body) as List<dynamic>;
+
+    return orgsData.map((repData) {
+      final org = repData as Map<String, dynamic>;
+
+      return GitHubRestOrganization(
+        login: org["login"],
+        avatarUrl: org["avatar_url"],
+      );
+    }).toList();
+  }
+
+  Future<List<GitHubRestRepository>> getRepositories(
+    String pat,
+    String org,
+  ) async {
+    // GitHub APIでリポジトリ情報を取得
+    final reposResponse = await http.get(
+      Uri.parse('$_baseUrl/orgs/$org/repos?per_page=100'),
       headers: {
         'Authorization': 'Bearer $pat',
         'Accept': 'application/vnd.github+json',
@@ -69,17 +99,10 @@ class GitHubRestClient {
 
     return reposData.map((repo) {
       final repoMap = repo as Map<String, dynamic>;
-      final owner = repoMap['owner'] as Map<String, dynamic>;
 
       return GitHubRestRepository(
-        organization: GitHubRestOrganization(
-          login: owner["login"],
-          htmlUrl: owner["html_url"],
-          avatarUrl: owner["avatar_url"],
-        ),
         name: repoMap['name'] as String,
         htmlUrl: repoMap['html_url'] as String,
-        avatarUrl: owner['avatar_url'] as String,
       );
     }).toList();
   }

--- a/lib/domain/models/github.dart
+++ b/lib/domain/models/github.dart
@@ -57,3 +57,26 @@ sealed class GitHubRestUser with _$GitHubRestUser {
     required DateTime expiresAt,
   }) = _GitHubRestUser;
 }
+
+@freezed
+sealed class GitHubRestOrganization with _$GitHubRestOrganization {
+  const GitHubRestOrganization._();
+
+  const factory GitHubRestOrganization({
+    required String login,
+    required String htmlUrl,
+    required String avatarUrl,
+  }) = _GitHubRestOrganization;
+}
+
+@freezed
+sealed class GitHubRestRepository with _$GitHubRestRepository {
+  const GitHubRestRepository._();
+
+  const factory GitHubRestRepository({
+    required GitHubRestOrganization organization,
+    required String name,
+    required String htmlUrl,
+    required String avatarUrl,
+  }) = _GitHubRestRepository;
+}

--- a/lib/domain/models/github.dart
+++ b/lib/domain/models/github.dart
@@ -64,7 +64,6 @@ sealed class GitHubRestOrganization with _$GitHubRestOrganization {
 
   const factory GitHubRestOrganization({
     required String login,
-    required String htmlUrl,
     required String avatarUrl,
   }) = _GitHubRestOrganization;
 }
@@ -74,9 +73,7 @@ sealed class GitHubRestRepository with _$GitHubRestRepository {
   const GitHubRestRepository._();
 
   const factory GitHubRestRepository({
-    required GitHubRestOrganization organization,
     required String name,
     required String htmlUrl,
-    required String avatarUrl,
   }) = _GitHubRestRepository;
 }

--- a/lib/domain/models/github.freezed.dart
+++ b/lib/domain/models/github.freezed.dart
@@ -1087,4 +1087,539 @@ as DateTime,
 
 }
 
+/// @nodoc
+mixin _$GitHubRestOrganization {
+
+ String get login; String get htmlUrl; String get avatarUrl;
+/// Create a copy of GitHubRestOrganization
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GitHubRestOrganizationCopyWith<GitHubRestOrganization> get copyWith => _$GitHubRestOrganizationCopyWithImpl<GitHubRestOrganization>(this as GitHubRestOrganization, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GitHubRestOrganization&&(identical(other.login, login) || other.login == login)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,login,htmlUrl,avatarUrl);
+
+@override
+String toString() {
+  return 'GitHubRestOrganization(login: $login, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GitHubRestOrganizationCopyWith<$Res>  {
+  factory $GitHubRestOrganizationCopyWith(GitHubRestOrganization value, $Res Function(GitHubRestOrganization) _then) = _$GitHubRestOrganizationCopyWithImpl;
+@useResult
+$Res call({
+ String login, String htmlUrl, String avatarUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$GitHubRestOrganizationCopyWithImpl<$Res>
+    implements $GitHubRestOrganizationCopyWith<$Res> {
+  _$GitHubRestOrganizationCopyWithImpl(this._self, this._then);
+
+  final GitHubRestOrganization _self;
+  final $Res Function(GitHubRestOrganization) _then;
+
+/// Create a copy of GitHubRestOrganization
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? login = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+  return _then(_self.copyWith(
+login: null == login ? _self.login : login // ignore: cast_nullable_to_non_nullable
+as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
+as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GitHubRestOrganization].
+extension GitHubRestOrganizationPatterns on GitHubRestOrganization {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GitHubRestOrganization value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GitHubRestOrganization() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GitHubRestOrganization value)  $default,){
+final _that = this;
+switch (_that) {
+case _GitHubRestOrganization():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GitHubRestOrganization value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GitHubRestOrganization() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String login,  String htmlUrl,  String avatarUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GitHubRestOrganization() when $default != null:
+return $default(_that.login,_that.htmlUrl,_that.avatarUrl);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String login,  String htmlUrl,  String avatarUrl)  $default,) {final _that = this;
+switch (_that) {
+case _GitHubRestOrganization():
+return $default(_that.login,_that.htmlUrl,_that.avatarUrl);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String login,  String htmlUrl,  String avatarUrl)?  $default,) {final _that = this;
+switch (_that) {
+case _GitHubRestOrganization() when $default != null:
+return $default(_that.login,_that.htmlUrl,_that.avatarUrl);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _GitHubRestOrganization extends GitHubRestOrganization {
+  const _GitHubRestOrganization({required this.login, required this.htmlUrl, required this.avatarUrl}): super._();
+  
+
+@override final  String login;
+@override final  String htmlUrl;
+@override final  String avatarUrl;
+
+/// Create a copy of GitHubRestOrganization
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GitHubRestOrganizationCopyWith<_GitHubRestOrganization> get copyWith => __$GitHubRestOrganizationCopyWithImpl<_GitHubRestOrganization>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GitHubRestOrganization&&(identical(other.login, login) || other.login == login)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,login,htmlUrl,avatarUrl);
+
+@override
+String toString() {
+  return 'GitHubRestOrganization(login: $login, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GitHubRestOrganizationCopyWith<$Res> implements $GitHubRestOrganizationCopyWith<$Res> {
+  factory _$GitHubRestOrganizationCopyWith(_GitHubRestOrganization value, $Res Function(_GitHubRestOrganization) _then) = __$GitHubRestOrganizationCopyWithImpl;
+@override @useResult
+$Res call({
+ String login, String htmlUrl, String avatarUrl
+});
+
+
+
+
+}
+/// @nodoc
+class __$GitHubRestOrganizationCopyWithImpl<$Res>
+    implements _$GitHubRestOrganizationCopyWith<$Res> {
+  __$GitHubRestOrganizationCopyWithImpl(this._self, this._then);
+
+  final _GitHubRestOrganization _self;
+  final $Res Function(_GitHubRestOrganization) _then;
+
+/// Create a copy of GitHubRestOrganization
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? login = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+  return _then(_GitHubRestOrganization(
+login: null == login ? _self.login : login // ignore: cast_nullable_to_non_nullable
+as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
+as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$GitHubRestRepository {
+
+ GitHubRestOrganization get organization; String get name; String get htmlUrl; String get avatarUrl;
+/// Create a copy of GitHubRestRepository
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GitHubRestRepositoryCopyWith<GitHubRestRepository> get copyWith => _$GitHubRestRepositoryCopyWithImpl<GitHubRestRepository>(this as GitHubRestRepository, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GitHubRestRepository&&(identical(other.organization, organization) || other.organization == organization)&&(identical(other.name, name) || other.name == name)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,organization,name,htmlUrl,avatarUrl);
+
+@override
+String toString() {
+  return 'GitHubRestRepository(organization: $organization, name: $name, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GitHubRestRepositoryCopyWith<$Res>  {
+  factory $GitHubRestRepositoryCopyWith(GitHubRestRepository value, $Res Function(GitHubRestRepository) _then) = _$GitHubRestRepositoryCopyWithImpl;
+@useResult
+$Res call({
+ GitHubRestOrganization organization, String name, String htmlUrl, String avatarUrl
+});
+
+
+$GitHubRestOrganizationCopyWith<$Res> get organization;
+
+}
+/// @nodoc
+class _$GitHubRestRepositoryCopyWithImpl<$Res>
+    implements $GitHubRestRepositoryCopyWith<$Res> {
+  _$GitHubRestRepositoryCopyWithImpl(this._self, this._then);
+
+  final GitHubRestRepository _self;
+  final $Res Function(GitHubRestRepository) _then;
+
+/// Create a copy of GitHubRestRepository
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? organization = null,Object? name = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+  return _then(_self.copyWith(
+organization: null == organization ? _self.organization : organization // ignore: cast_nullable_to_non_nullable
+as GitHubRestOrganization,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
+as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+/// Create a copy of GitHubRestRepository
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GitHubRestOrganizationCopyWith<$Res> get organization {
+  
+  return $GitHubRestOrganizationCopyWith<$Res>(_self.organization, (value) {
+    return _then(_self.copyWith(organization: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [GitHubRestRepository].
+extension GitHubRestRepositoryPatterns on GitHubRestRepository {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GitHubRestRepository value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GitHubRestRepository() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GitHubRestRepository value)  $default,){
+final _that = this;
+switch (_that) {
+case _GitHubRestRepository():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GitHubRestRepository value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GitHubRestRepository() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( GitHubRestOrganization organization,  String name,  String htmlUrl,  String avatarUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GitHubRestRepository() when $default != null:
+return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( GitHubRestOrganization organization,  String name,  String htmlUrl,  String avatarUrl)  $default,) {final _that = this;
+switch (_that) {
+case _GitHubRestRepository():
+return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( GitHubRestOrganization organization,  String name,  String htmlUrl,  String avatarUrl)?  $default,) {final _that = this;
+switch (_that) {
+case _GitHubRestRepository() when $default != null:
+return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _GitHubRestRepository extends GitHubRestRepository {
+  const _GitHubRestRepository({required this.organization, required this.name, required this.htmlUrl, required this.avatarUrl}): super._();
+  
+
+@override final  GitHubRestOrganization organization;
+@override final  String name;
+@override final  String htmlUrl;
+@override final  String avatarUrl;
+
+/// Create a copy of GitHubRestRepository
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GitHubRestRepositoryCopyWith<_GitHubRestRepository> get copyWith => __$GitHubRestRepositoryCopyWithImpl<_GitHubRestRepository>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GitHubRestRepository&&(identical(other.organization, organization) || other.organization == organization)&&(identical(other.name, name) || other.name == name)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,organization,name,htmlUrl,avatarUrl);
+
+@override
+String toString() {
+  return 'GitHubRestRepository(organization: $organization, name: $name, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GitHubRestRepositoryCopyWith<$Res> implements $GitHubRestRepositoryCopyWith<$Res> {
+  factory _$GitHubRestRepositoryCopyWith(_GitHubRestRepository value, $Res Function(_GitHubRestRepository) _then) = __$GitHubRestRepositoryCopyWithImpl;
+@override @useResult
+$Res call({
+ GitHubRestOrganization organization, String name, String htmlUrl, String avatarUrl
+});
+
+
+@override $GitHubRestOrganizationCopyWith<$Res> get organization;
+
+}
+/// @nodoc
+class __$GitHubRestRepositoryCopyWithImpl<$Res>
+    implements _$GitHubRestRepositoryCopyWith<$Res> {
+  __$GitHubRestRepositoryCopyWithImpl(this._self, this._then);
+
+  final _GitHubRestRepository _self;
+  final $Res Function(_GitHubRestRepository) _then;
+
+/// Create a copy of GitHubRestRepository
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? organization = null,Object? name = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+  return _then(_GitHubRestRepository(
+organization: null == organization ? _self.organization : organization // ignore: cast_nullable_to_non_nullable
+as GitHubRestOrganization,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
+as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+/// Create a copy of GitHubRestRepository
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GitHubRestOrganizationCopyWith<$Res> get organization {
+  
+  return $GitHubRestOrganizationCopyWith<$Res>(_self.organization, (value) {
+    return _then(_self.copyWith(organization: value));
+  });
+}
+}
+
 // dart format on

--- a/lib/domain/models/github.freezed.dart
+++ b/lib/domain/models/github.freezed.dart
@@ -1090,7 +1090,7 @@ as DateTime,
 /// @nodoc
 mixin _$GitHubRestOrganization {
 
- String get login; String get htmlUrl; String get avatarUrl;
+ String get login; String get avatarUrl;
 /// Create a copy of GitHubRestOrganization
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1101,16 +1101,16 @@ $GitHubRestOrganizationCopyWith<GitHubRestOrganization> get copyWith => _$GitHub
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GitHubRestOrganization&&(identical(other.login, login) || other.login == login)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GitHubRestOrganization&&(identical(other.login, login) || other.login == login)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,login,htmlUrl,avatarUrl);
+int get hashCode => Object.hash(runtimeType,login,avatarUrl);
 
 @override
 String toString() {
-  return 'GitHubRestOrganization(login: $login, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+  return 'GitHubRestOrganization(login: $login, avatarUrl: $avatarUrl)';
 }
 
 
@@ -1121,7 +1121,7 @@ abstract mixin class $GitHubRestOrganizationCopyWith<$Res>  {
   factory $GitHubRestOrganizationCopyWith(GitHubRestOrganization value, $Res Function(GitHubRestOrganization) _then) = _$GitHubRestOrganizationCopyWithImpl;
 @useResult
 $Res call({
- String login, String htmlUrl, String avatarUrl
+ String login, String avatarUrl
 });
 
 
@@ -1138,10 +1138,9 @@ class _$GitHubRestOrganizationCopyWithImpl<$Res>
 
 /// Create a copy of GitHubRestOrganization
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? login = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? login = null,Object? avatarUrl = null,}) {
   return _then(_self.copyWith(
 login: null == login ? _self.login : login // ignore: cast_nullable_to_non_nullable
-as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
 as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
@@ -1225,10 +1224,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String login,  String htmlUrl,  String avatarUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String login,  String avatarUrl)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GitHubRestOrganization() when $default != null:
-return $default(_that.login,_that.htmlUrl,_that.avatarUrl);case _:
+return $default(_that.login,_that.avatarUrl);case _:
   return orElse();
 
 }
@@ -1246,10 +1245,10 @@ return $default(_that.login,_that.htmlUrl,_that.avatarUrl);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String login,  String htmlUrl,  String avatarUrl)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String login,  String avatarUrl)  $default,) {final _that = this;
 switch (_that) {
 case _GitHubRestOrganization():
-return $default(_that.login,_that.htmlUrl,_that.avatarUrl);}
+return $default(_that.login,_that.avatarUrl);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -1263,10 +1262,10 @@ return $default(_that.login,_that.htmlUrl,_that.avatarUrl);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String login,  String htmlUrl,  String avatarUrl)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String login,  String avatarUrl)?  $default,) {final _that = this;
 switch (_that) {
 case _GitHubRestOrganization() when $default != null:
-return $default(_that.login,_that.htmlUrl,_that.avatarUrl);case _:
+return $default(_that.login,_that.avatarUrl);case _:
   return null;
 
 }
@@ -1278,11 +1277,10 @@ return $default(_that.login,_that.htmlUrl,_that.avatarUrl);case _:
 
 
 class _GitHubRestOrganization extends GitHubRestOrganization {
-  const _GitHubRestOrganization({required this.login, required this.htmlUrl, required this.avatarUrl}): super._();
+  const _GitHubRestOrganization({required this.login, required this.avatarUrl}): super._();
   
 
 @override final  String login;
-@override final  String htmlUrl;
 @override final  String avatarUrl;
 
 /// Create a copy of GitHubRestOrganization
@@ -1295,16 +1293,16 @@ _$GitHubRestOrganizationCopyWith<_GitHubRestOrganization> get copyWith => __$Git
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GitHubRestOrganization&&(identical(other.login, login) || other.login == login)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GitHubRestOrganization&&(identical(other.login, login) || other.login == login)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,login,htmlUrl,avatarUrl);
+int get hashCode => Object.hash(runtimeType,login,avatarUrl);
 
 @override
 String toString() {
-  return 'GitHubRestOrganization(login: $login, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+  return 'GitHubRestOrganization(login: $login, avatarUrl: $avatarUrl)';
 }
 
 
@@ -1315,7 +1313,7 @@ abstract mixin class _$GitHubRestOrganizationCopyWith<$Res> implements $GitHubRe
   factory _$GitHubRestOrganizationCopyWith(_GitHubRestOrganization value, $Res Function(_GitHubRestOrganization) _then) = __$GitHubRestOrganizationCopyWithImpl;
 @override @useResult
 $Res call({
- String login, String htmlUrl, String avatarUrl
+ String login, String avatarUrl
 });
 
 
@@ -1332,10 +1330,9 @@ class __$GitHubRestOrganizationCopyWithImpl<$Res>
 
 /// Create a copy of GitHubRestOrganization
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? login = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? login = null,Object? avatarUrl = null,}) {
   return _then(_GitHubRestOrganization(
 login: null == login ? _self.login : login // ignore: cast_nullable_to_non_nullable
-as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
 as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
@@ -1347,7 +1344,7 @@ as String,
 /// @nodoc
 mixin _$GitHubRestRepository {
 
- GitHubRestOrganization get organization; String get name; String get htmlUrl; String get avatarUrl;
+ String get name; String get htmlUrl;
 /// Create a copy of GitHubRestRepository
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1358,16 +1355,16 @@ $GitHubRestRepositoryCopyWith<GitHubRestRepository> get copyWith => _$GitHubRest
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GitHubRestRepository&&(identical(other.organization, organization) || other.organization == organization)&&(identical(other.name, name) || other.name == name)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GitHubRestRepository&&(identical(other.name, name) || other.name == name)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,organization,name,htmlUrl,avatarUrl);
+int get hashCode => Object.hash(runtimeType,name,htmlUrl);
 
 @override
 String toString() {
-  return 'GitHubRestRepository(organization: $organization, name: $name, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+  return 'GitHubRestRepository(name: $name, htmlUrl: $htmlUrl)';
 }
 
 
@@ -1378,11 +1375,11 @@ abstract mixin class $GitHubRestRepositoryCopyWith<$Res>  {
   factory $GitHubRestRepositoryCopyWith(GitHubRestRepository value, $Res Function(GitHubRestRepository) _then) = _$GitHubRestRepositoryCopyWithImpl;
 @useResult
 $Res call({
- GitHubRestOrganization organization, String name, String htmlUrl, String avatarUrl
+ String name, String htmlUrl
 });
 
 
-$GitHubRestOrganizationCopyWith<$Res> get organization;
+
 
 }
 /// @nodoc
@@ -1395,25 +1392,14 @@ class _$GitHubRestRepositoryCopyWithImpl<$Res>
 
 /// Create a copy of GitHubRestRepository
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? organization = null,Object? name = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? htmlUrl = null,}) {
   return _then(_self.copyWith(
-organization: null == organization ? _self.organization : organization // ignore: cast_nullable_to_non_nullable
-as GitHubRestOrganization,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
-as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
-/// Create a copy of GitHubRestRepository
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$GitHubRestOrganizationCopyWith<$Res> get organization {
-  
-  return $GitHubRestOrganizationCopyWith<$Res>(_self.organization, (value) {
-    return _then(_self.copyWith(organization: value));
-  });
-}
+
 }
 
 
@@ -1492,10 +1478,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( GitHubRestOrganization organization,  String name,  String htmlUrl,  String avatarUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String htmlUrl)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GitHubRestRepository() when $default != null:
-return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);case _:
+return $default(_that.name,_that.htmlUrl);case _:
   return orElse();
 
 }
@@ -1513,10 +1499,10 @@ return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);cas
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( GitHubRestOrganization organization,  String name,  String htmlUrl,  String avatarUrl)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String htmlUrl)  $default,) {final _that = this;
 switch (_that) {
 case _GitHubRestRepository():
-return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);}
+return $default(_that.name,_that.htmlUrl);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -1530,10 +1516,10 @@ return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( GitHubRestOrganization organization,  String name,  String htmlUrl,  String avatarUrl)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String htmlUrl)?  $default,) {final _that = this;
 switch (_that) {
 case _GitHubRestRepository() when $default != null:
-return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);case _:
+return $default(_that.name,_that.htmlUrl);case _:
   return null;
 
 }
@@ -1545,13 +1531,11 @@ return $default(_that.organization,_that.name,_that.htmlUrl,_that.avatarUrl);cas
 
 
 class _GitHubRestRepository extends GitHubRestRepository {
-  const _GitHubRestRepository({required this.organization, required this.name, required this.htmlUrl, required this.avatarUrl}): super._();
+  const _GitHubRestRepository({required this.name, required this.htmlUrl}): super._();
   
 
-@override final  GitHubRestOrganization organization;
 @override final  String name;
 @override final  String htmlUrl;
-@override final  String avatarUrl;
 
 /// Create a copy of GitHubRestRepository
 /// with the given fields replaced by the non-null parameter values.
@@ -1563,16 +1547,16 @@ _$GitHubRestRepositoryCopyWith<_GitHubRestRepository> get copyWith => __$GitHubR
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GitHubRestRepository&&(identical(other.organization, organization) || other.organization == organization)&&(identical(other.name, name) || other.name == name)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GitHubRestRepository&&(identical(other.name, name) || other.name == name)&&(identical(other.htmlUrl, htmlUrl) || other.htmlUrl == htmlUrl));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,organization,name,htmlUrl,avatarUrl);
+int get hashCode => Object.hash(runtimeType,name,htmlUrl);
 
 @override
 String toString() {
-  return 'GitHubRestRepository(organization: $organization, name: $name, htmlUrl: $htmlUrl, avatarUrl: $avatarUrl)';
+  return 'GitHubRestRepository(name: $name, htmlUrl: $htmlUrl)';
 }
 
 
@@ -1583,11 +1567,11 @@ abstract mixin class _$GitHubRestRepositoryCopyWith<$Res> implements $GitHubRest
   factory _$GitHubRestRepositoryCopyWith(_GitHubRestRepository value, $Res Function(_GitHubRestRepository) _then) = __$GitHubRestRepositoryCopyWithImpl;
 @override @useResult
 $Res call({
- GitHubRestOrganization organization, String name, String htmlUrl, String avatarUrl
+ String name, String htmlUrl
 });
 
 
-@override $GitHubRestOrganizationCopyWith<$Res> get organization;
+
 
 }
 /// @nodoc
@@ -1600,26 +1584,15 @@ class __$GitHubRestRepositoryCopyWithImpl<$Res>
 
 /// Create a copy of GitHubRestRepository
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? organization = null,Object? name = null,Object? htmlUrl = null,Object? avatarUrl = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? htmlUrl = null,}) {
   return _then(_GitHubRestRepository(
-organization: null == organization ? _self.organization : organization // ignore: cast_nullable_to_non_nullable
-as GitHubRestOrganization,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,htmlUrl: null == htmlUrl ? _self.htmlUrl : htmlUrl // ignore: cast_nullable_to_non_nullable
-as String,avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
 
-/// Create a copy of GitHubRestRepository
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$GitHubRestOrganizationCopyWith<$Res> get organization {
-  
-  return $GitHubRestOrganizationCopyWith<$Res>(_self.organization, (value) {
-    return _then(_self.copyWith(organization: value));
-  });
-}
+
 }
 
 // dart format on

--- a/lib/ui/setting/widgets/github_repository_form.dart
+++ b/lib/ui/setting/widgets/github_repository_form.dart
@@ -17,20 +17,21 @@ class GitHubRepositoryForm extends HookConsumerWidget {
     final repositories = useState<List<GitHubRestRepository>>([]);
     final selectedOrganization = useState<GitHubRestOrganization?>(null);
     final selectedRepository = useState<GitHubRestRepository?>(null);
-    final isLoading = useState(false);
+    final isLoadingOrgs = useState(false);
+    final isLoadingRepos = useState(false);
 
+    // 組織リストを読み込み
     useEffect(() {
       Future<void> loadOrganizations() async {
-        isLoading.value = true;
+        isLoadingOrgs.value = true;
         try {
           final client = GitHubRestClient();
           final orgs = await client.getOrganizations(_account.pat);
           organizations.value = orgs;
         } catch (e) {
-          // エラーハンドリング
           debugPrint('Failed to load organizations: $e');
         } finally {
-          isLoading.value = false;
+          isLoadingOrgs.value = false;
         }
       }
 
@@ -38,36 +39,68 @@ class GitHubRepositoryForm extends HookConsumerWidget {
       return null;
     }, []);
 
+    // 組織が選択されたらリポジトリを読み込み
+    useEffect(() {
+      Future<void> loadRepositories() async {
+        if (selectedOrganization.value == null) {
+          repositories.value = [];
+          return;
+        }
+
+        isLoadingRepos.value = true;
+        selectedRepository.value = null; // リポジトリ選択をリセット
+        try {
+          final client = GitHubRestClient();
+          final repos = await client.getRepositories(
+            _account.pat,
+            selectedOrganization.value!.login,
+          );
+          repositories.value = repos;
+        } catch (e) {
+          debugPrint('Failed to load repositories: $e');
+          repositories.value = [];
+        } finally {
+          isLoadingRepos.value = false;
+        }
+      }
+
+      loadRepositories();
+      return null;
+    }, [selectedOrganization.value]);
+
     return TRow(
       vAlign: TRowVAlign.center,
       gap: 2,
       children: [
-        TSelect<GitHubRestOrganization>(
-          size: 160,
-          items:
-              organizations.value
-                  .map((org) => TSelectItem(org, org.login))
-                  .toList(),
-          value: selectedOrganization.value,
-          onChanged: (value) {
-            selectedOrganization.value = value;
-          },
-        ),
-        TSelect<GitHubRestRepository>(
-          size: 160,
-          items:
-              repositories.value
-                  .map((repo) => TSelectItem(repo, repo.name))
-                  .toList(),
-          value: selectedRepository.value,
-          onChanged: (value) {
-            selectedRepository.value = value;
-          },
-        ),
+        isLoadingOrgs.value
+            ? const TProgress()
+            : TSelect<GitHubRestOrganization>(
+              size: 160,
+              items:
+                  organizations.value
+                      .map((org) => TSelectItem(org, org.login))
+                      .toList(),
+              value: selectedOrganization.value,
+              onChanged: (value) {
+                selectedOrganization.value = value;
+              },
+            ),
+        isLoadingRepos.value
+            ? const TProgress()
+            : TSelect<GitHubRestRepository>(
+              size: 160,
+              items:
+                  repositories.value
+                      .map((repo) => TSelectItem(repo, repo.name))
+                      .toList(),
+              value: selectedRepository.value,
+              onChanged: (value) {
+                selectedRepository.value = value;
+              },
+            ),
         TButton(
           text: "Add",
           onPressed: (_) {
-            // リポジトリを追加する処理
             if (selectedRepository.value != null) {
               debugPrint(
                 'Adding repository: ${selectedRepository.value!.name}',

--- a/lib/ui/setting/widgets/github_repository_form.dart
+++ b/lib/ui/setting/widgets/github_repository_form.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tellyou/ui/widgets.dart';
+
+class GitHubRepositoryForm extends HookConsumerWidget {
+  const GitHubRepositoryForm({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return TRow(
+      vAlign: TRowVAlign.center,
+      gap: 2,
+      children: [
+        TSelect(items: [], onChanged: (_) {}),
+        TButton(text: "Add", onPressed: (_) {}),
+      ],
+    );
+  }
+}

--- a/lib/ui/setting/widgets/github_repository_form.dart
+++ b/lib/ui/setting/widgets/github_repository_form.dart
@@ -13,26 +13,28 @@ class GitHubRepositoryForm extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final organizations = useState<List<GitHubRestOrganization>>([]);
     final repositories = useState<List<GitHubRestRepository>>([]);
+    final selectedOrganization = useState<GitHubRestOrganization?>(null);
     final selectedRepository = useState<GitHubRestRepository?>(null);
     final isLoading = useState(false);
 
     useEffect(() {
-      Future<void> loadRepositories() async {
+      Future<void> loadOrganizations() async {
         isLoading.value = true;
         try {
           final client = GitHubRestClient();
-          final repos = await client.getRepositories(_account.pat);
-          repositories.value = repos;
+          final orgs = await client.getOrganizations(_account.pat);
+          organizations.value = orgs;
         } catch (e) {
           // エラーハンドリング
-          debugPrint('Failed to load repositories: $e');
+          debugPrint('Failed to load organizations: $e');
         } finally {
           isLoading.value = false;
         }
       }
 
-      loadRepositories();
+      loadOrganizations();
       return null;
     }, []);
 
@@ -40,23 +42,28 @@ class GitHubRepositoryForm extends HookConsumerWidget {
       vAlign: TRowVAlign.center,
       gap: 2,
       children: [
-        isLoading.value
-            ? const TProgress()
-            : TSelect<GitHubRestRepository>(
-              items:
-                  repositories.value
-                      .map(
-                        (repo) => TSelectItem(
-                          repo,
-                          '${repo.organization.login}/${repo.name}',
-                        ),
-                      )
-                      .toList(),
-              value: selectedRepository.value,
-              onChanged: (value) {
-                selectedRepository.value = value;
-              },
-            ),
+        TSelect<GitHubRestOrganization>(
+          size: 160,
+          items:
+              organizations.value
+                  .map((org) => TSelectItem(org, org.login))
+                  .toList(),
+          value: selectedOrganization.value,
+          onChanged: (value) {
+            selectedOrganization.value = value;
+          },
+        ),
+        TSelect<GitHubRestRepository>(
+          size: 160,
+          items:
+              repositories.value
+                  .map((repo) => TSelectItem(repo, repo.name))
+                  .toList(),
+          value: selectedRepository.value,
+          onChanged: (value) {
+            selectedRepository.value = value;
+          },
+        ),
         TButton(
           text: "Add",
           onPressed: (_) {

--- a/lib/ui/setting/widgets/github_repository_form.dart
+++ b/lib/ui/setting/widgets/github_repository_form.dart
@@ -1,18 +1,73 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tellyou/data/clients/github_rest_client.dart';
+import 'package:tellyou/domain/models/github.dart';
 import 'package:tellyou/ui/widgets.dart';
 
 class GitHubRepositoryForm extends HookConsumerWidget {
-  const GitHubRepositoryForm({super.key});
+  final GitHubAccount _account;
+
+  const GitHubRepositoryForm({super.key, required GitHubAccount account})
+    : _account = account;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final repositories = useState<List<GitHubRestRepository>>([]);
+    final selectedRepository = useState<GitHubRestRepository?>(null);
+    final isLoading = useState(false);
+
+    useEffect(() {
+      Future<void> loadRepositories() async {
+        isLoading.value = true;
+        try {
+          final client = GitHubRestClient();
+          final repos = await client.getRepositories(_account.pat);
+          repositories.value = repos;
+        } catch (e) {
+          // エラーハンドリング
+          debugPrint('Failed to load repositories: $e');
+        } finally {
+          isLoading.value = false;
+        }
+      }
+
+      loadRepositories();
+      return null;
+    }, []);
+
     return TRow(
       vAlign: TRowVAlign.center,
       gap: 2,
       children: [
-        TSelect(items: [], onChanged: (_) {}),
-        TButton(text: "Add", onPressed: (_) {}),
+        isLoading.value
+            ? const TProgress()
+            : TSelect<GitHubRestRepository>(
+              items:
+                  repositories.value
+                      .map(
+                        (repo) => TSelectItem(
+                          repo,
+                          '${repo.organization.login}/${repo.name}',
+                        ),
+                      )
+                      .toList(),
+              value: selectedRepository.value,
+              onChanged: (value) {
+                selectedRepository.value = value;
+              },
+            ),
+        TButton(
+          text: "Add",
+          onPressed: (_) {
+            // リポジトリを追加する処理
+            if (selectedRepository.value != null) {
+              debugPrint(
+                'Adding repository: ${selectedRepository.value!.name}',
+              );
+            }
+          },
+        ),
       ],
     );
   }

--- a/lib/ui/setting/widgets/github_view.dart
+++ b/lib/ui/setting/widgets/github_view.dart
@@ -52,7 +52,7 @@ class SettingGitHubView extends HookConsumerWidget {
                                   organization: organization,
                                   repositories: organization.repositories,
                                 ),
-                              GitHubRepositoryForm(),
+                              GitHubRepositoryForm(account: account),
                             ],
                           ),
                         ),

--- a/lib/ui/setting/widgets/github_view.dart
+++ b/lib/ui/setting/widgets/github_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:tellyou/ui/setting/widgets/github_pat_register_dialog.dart';
+import 'package:tellyou/ui/setting/widgets/github_repository_form.dart';
 
 import "package:tellyou/ui/widgets.dart";
 import 'package:tellyou/ui/setting/view_model.dart';
@@ -38,18 +39,20 @@ class SettingGitHubView extends HookConsumerWidget {
                 children: [
                   for (final account in state.accounts)
                     TColumn(
-                      gap: 1,
+                      gap: 2,
                       children: [
                         SettingGitHubAccountView(account: account),
                         TPadding(
                           left: 16,
                           child: TColumn(
+                            gap: 1,
                             children: [
                               for (final organization in account.organizations)
                                 SettingGitHubRepositoryTable(
                                   organization: organization,
                                   repositories: organization.repositories,
                                 ),
+                              GitHubRepositoryForm(),
                             ],
                           ),
                         ),

--- a/lib/ui/widgets.dart
+++ b/lib/ui/widgets.dart
@@ -11,6 +11,7 @@ export "package:tellyou/ui/widgets/feedback/dialog.dart";
 export "package:tellyou/ui/widgets/form/button.dart";
 export "package:tellyou/ui/widgets/form/icon_button.dart";
 export "package:tellyou/ui/widgets/form/form_field.dart";
+export "package:tellyou/ui/widgets/form/select.dart";
 export "package:tellyou/ui/widgets/form/text_field.dart";
 
 // layout

--- a/lib/ui/widgets/form/select.dart
+++ b/lib/ui/widgets/form/select.dart
@@ -1,0 +1,61 @@
+// Flutter imports:
+import "package:flutter/material.dart";
+
+// Project imports:
+import "package:tellyou/ui/widgets.dart";
+
+class TSelectItem<T> {
+  final T _value;
+  final String _text;
+
+  TSelectItem(this._value, this._text);
+}
+
+class TSelect<T> extends StatelessWidget {
+  final String? _label;
+  final T? _value;
+  final double _size;
+  final List<TSelectItem<T>> _items;
+  final void Function(T?) _onChanged;
+
+  const TSelect({
+    super.key,
+    String? label,
+    T? value,
+    double size = 320,
+    required List<TSelectItem<T>> items,
+    required void Function(T?) onChanged,
+  }) : _label = label,
+       _value = value,
+       _size = size,
+       _items = items,
+       _onChanged = onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: _size,
+      child: DropdownButtonFormField<T>(
+        initialValue: _value,
+        onChanged: (value) {
+          _onChanged(value);
+        },
+        items:
+            _items.map((item) {
+              return DropdownMenuItem<T>(
+                value: item._value,
+                child: TText(item._text),
+              );
+            }).toList(),
+        decoration: InputDecoration(
+          labelText: _label,
+          isDense: true,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(4.0)),
+          ),
+        ),
+        isExpanded: true,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概要
GitHubアカウントに紐づく個人リポジトリと組織リポジトリを選択できる機能を実装

## 対応Issue
- fixes: https://github.com/pkshimizu/tellyou/issues/10

## 詳細
- GitHubRestClientにリポジトリ取得API機能を追加
  - `getOrganizations`: 個人アカウントと所属組織のリストを取得
  - `getRepositories`: 指定した所有者（個人/組織）のリポジトリリストを取得
- GitHubRestOrganizationとGitHubRestRepositoryモデルを追加
- セレクトコンポーネント（TSelect）を新規作成
- GitHubRepositoryFormを実装
  - 組織選択時に自動的にリポジトリリストを取得
  - 個別のローディング状態管理
- SettingGitHubViewにリポジトリフォームを統合